### PR TITLE
Fix issue with directly looping over an sp8_lif object

### DIFF
--- a/scm_confocal/__init__.py
+++ b/scm_confocal/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 from .sp8 import sp8_lif,sp8_image,sp8_series
 from .visitech import visitech_series,visitech_faststack

--- a/scm_confocal/sp8.py
+++ b/scm_confocal/sp8.py
@@ -82,6 +82,9 @@ class sp8_lif:
     
     def __getitem__(self,i):
         """allows using indexing as a shorthand for `get_image()`"""
+        if i >= len(self):
+            raise IndexError(f"Index {i} is out of range for image_list with"\
+                              f" size {len(self)}")
         return self.get_image(i)
     
     def __repr__(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="scm_confocal",
-    version="1.4.0",
+    version="1.4.1",
     author="Maarten Bransen",
     author_email="m.bransen@uu.nl",
     license='GNU General Public License v3.0',


### PR DESCRIPTION
Fixes the issue when looping directly over an `sp8_lif` object, e.g. this is now possible without errors:
```python
data = sp8_lif(filename)
for image in data:
    print(image)
```